### PR TITLE
Fix missing Workday controller actions

### DIFF
--- a/app/Http/Controllers/Admin/WorkdayController.php
+++ b/app/Http/Controllers/Admin/WorkdayController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Models\Workday;
 use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
 
 class WorkdayController extends Controller
 {

--- a/app/Http/Controllers/WorkdayController.php
+++ b/app/Http/Controllers/WorkdayController.php
@@ -2,9 +2,26 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Workday;
 use Illuminate\Http\Request;
 
 class WorkdayController extends Controller
 {
-    //
+    public function index()
+    {
+        $workdays = Workday::orderBy('day')->get();
+        return view('workdays.index', compact('workdays'));
+    }
+
+    public function signup(Workday $workday)
+    {
+        auth()->user()->workdays()->syncWithoutDetaching($workday->id);
+        return back()->with('success', 'Du bist dabei! 🎉');
+    }
+
+    public function cancel(Workday $workday)
+    {
+        auth()->user()->workdays()->detach($workday->id);
+        return back()->with('warning', 'Schade, dass du abspringst…');
+    }
 }

--- a/app/Models/Workday.php
+++ b/app/Models/Workday.php
@@ -6,5 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class Workday extends Model
 {
-    //
+    protected $fillable = [
+        'day',
+        'title',
+        'description',
+    ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
 }

--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -1,0 +1,53 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Workdays') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
+                <table class="min-w-full divide-y divide-gray-200">
+                    <thead class="bg-gray-50">
+                        <tr>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                {{ __('Date') }}
+                            </th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                {{ __('Title') }}
+                            </th>
+                            <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                {{ __('Description') }}
+                            </th>
+                            <th class="px-6 py-3"></th>
+                        </tr>
+                    </thead>
+                    <tbody class="bg-white divide-y divide-gray-200">
+                        @foreach($workdays as $workday)
+                            <tr>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ \Carbon\Carbon::parse($workday->day)->format('Y-m-d') }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $workday->title }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">{{ $workday->description }}</td>
+                                <td class="px-6 py-4 whitespace-nowrap">
+                                    @if(auth()->user()->workdays->contains($workday->id))
+                                        <form action="{{ route('workdays.cancel', $workday) }}" method="POST">
+                                            @csrf
+                                            @method('DELETE')
+                                            <x-secondary-button>{{ __('Cancel') }}</x-secondary-button>
+                                        </form>
+                                    @else
+                                        <form action="{{ route('workdays.signup', $workday) }}" method="POST">
+                                            @csrf
+                                            <x-primary-button>{{ __('Sign up') }}</x-primary-button>
+                                        </form>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- implement WorkdayController with index/signup/cancel actions
- add Workday model fields and users relation
- import base Controller in admin controller
- create basic workday listing view

## Testing
- `php artisan route:list | head`
- `./vendor/bin/pest | head`


------
https://chatgpt.com/codex/tasks/task_e_684478515928832d96b3c929180b60f1