### PR TITLE
Implement workday listing

### DIFF
--- a/app/Http/Controllers/WorkdayController.php
+++ b/app/Http/Controllers/WorkdayController.php
@@ -2,9 +2,38 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Workday;
 use Illuminate\Http\Request;
 
 class WorkdayController extends Controller
 {
-    //
+    /**
+     * Display a listing of available workdays.
+     */
+    public function index()
+    {
+        $workdays = Workday::orderBy('day')->get();
+
+        return view('workdays.index', compact('workdays'));
+    }
+
+    /**
+     * Sign the authenticated user up for a workday.
+     */
+    public function signup(Workday $workday)
+    {
+        auth()->user()->workdays()->attach($workday->id);
+
+        return back()->with('success', 'Du bist dabei! 🎉');
+    }
+
+    /**
+     * Cancel the authenticated user's participation for a workday.
+     */
+    public function cancel(Workday $workday)
+    {
+        auth()->user()->workdays()->detach($workday->id);
+
+        return back()->with('warning', 'Schade, dass du abspringst…');
+    }
 }

--- a/app/Models/Workday.php
+++ b/app/Models/Workday.php
@@ -6,5 +6,27 @@ use Illuminate\Database\Eloquent\Model;
 
 class Workday extends Model
 {
-    //
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = ['day', 'title', 'description'];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'day' => 'date',
+    ];
+
+    /**
+     * Users that are signed up for this workday.
+     */
+    public function users()
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
 }

--- a/database/migrations/2025_06_07_161004_create_user_workday_table.php
+++ b/database/migrations/2025_06_07_161004_create_user_workday_table.php
@@ -26,9 +26,4 @@ return new class extends Migration
     {
         Schema::dropIfExists('user_workday');
     }
-
-    public function users()
-    {
-        return $this->belongsToMany(User::class)->withTimestamps();
-    }
 };

--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -1,0 +1,45 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Meine Tage') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <table class="min-w-full">
+                    <thead>
+                        <tr>
+                            <th class="text-left">{{ __('Datum') }}</th>
+                            <th class="text-left">{{ __('Titel') }}</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($workdays as $workday)
+                            <tr class="border-t">
+                                <td class="py-2">{{ $workday->day->format('d.m.Y') }}</td>
+                                <td class="py-2">{{ $workday->title }}</td>
+                                <td class="py-2 text-right">
+                                    @if($workday->users->contains(auth()->user()))
+                                        <form method="POST" action="{{ route('workdays.cancel', $workday) }}">
+                                            @csrf
+                                            @method('DELETE')
+                                            <x-primary-button>{{ __('Absagen') }}</x-primary-button>
+                                        </form>
+                                    @else
+                                        <form method="POST" action="{{ route('workdays.signup', $workday) }}">
+                                            @csrf
+                                            <x-primary-button>{{ __('Anmelden') }}</x-primary-button>
+                                        </form>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</x-app-layout>


### PR DESCRIPTION
## Summary
- enable listing of workdays
- implement user signup/cancel actions
- define workday relationships and casts
- clean up user_workday migration

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68447b2b62e8832daca9bd6c3a4ce2f2