### PR TITLE
Add festival calendar management

### DIFF
--- a/app/Http/Controllers/Admin/FestivalController.php
+++ b/app/Http/Controllers/Admin/FestivalController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use App\Models\Festival;
+
+class FestivalController extends Controller
+{
+    public function edit()
+    {
+        $festival = Festival::first();
+        if (!$festival) {
+            $festival = Festival::create([
+                'aufbau_start' => now()->startOfMonth(),
+                'aufbau_end' => now()->startOfMonth()->addDays(2),
+                'festival_start' => now()->startOfMonth()->addDays(3),
+                'festival_end' => now()->startOfMonth()->addDays(5),
+                'abbau_start' => now()->startOfMonth()->addDays(6),
+                'abbau_end' => now()->startOfMonth()->addDays(7),
+            ]);
+        }
+
+        return view('admin.festival.edit', compact('festival'));
+    }
+
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'aufbau_start' => 'required|date',
+            'aufbau_end' => 'required|date',
+            'festival_start' => 'required|date',
+            'festival_end' => 'required|date',
+            'abbau_start' => 'required|date',
+            'abbau_end' => 'required|date',
+        ]);
+
+        $festival = Festival::first();
+        $festival->update($data);
+
+        return redirect()->route('admin.festival.edit')->with('success', 'Kalender gespeichert.');
+    }
+}

--- a/app/Models/Festival.php
+++ b/app/Models/Festival.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Festival extends Model
+{
+    protected $fillable = [
+        'aufbau_start',
+        'aufbau_end',
+        'festival_start',
+        'festival_end',
+        'abbau_start',
+        'abbau_end',
+    ];
+
+    protected $casts = [
+        'aufbau_start' => 'date',
+        'aufbau_end' => 'date',
+        'festival_start' => 'date',
+        'festival_end' => 'date',
+        'abbau_start' => 'date',
+        'abbau_end' => 'date',
+    ];
+}

--- a/database/migrations/2025_06_07_203246_create_festivals_table.php
+++ b/database/migrations/2025_06_07_203246_create_festivals_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('festivals', function (Blueprint $table) {
+            $table->id();
+            $table->date('aufbau_start')->nullable();
+            $table->date('aufbau_end')->nullable();
+            $table->date('festival_start')->nullable();
+            $table->date('festival_end')->nullable();
+            $table->date('abbau_start')->nullable();
+            $table->date('abbau_end')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('festivals');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\User;
+use Database\Seeders\FestivalSeeder;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -19,5 +20,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        $this->call(FestivalSeeder::class);
     }
 }

--- a/database/seeders/FestivalSeeder.php
+++ b/database/seeders/FestivalSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Festival;
+
+class FestivalSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Festival::create([
+            'aufbau_start' => '2025-06-01',
+            'aufbau_end' => '2025-06-05',
+            'festival_start' => '2025-06-06',
+            'festival_end' => '2025-06-10',
+            'abbau_start' => '2025-06-11',
+            'abbau_end' => '2025-06-13',
+        ]);
+    }
+}

--- a/resources/views/admin/festival/edit.blade.php
+++ b/resources/views/admin/festival/edit.blade.php
@@ -1,0 +1,49 @@
+<x-app-layout>
+    <x-slot name="header">
+        <h2 class="font-semibold text-xl text-gray-800 dark:text-gray-200 leading-tight">
+            {{ __('Festival Einstellungen') }}
+        </h2>
+    </x-slot>
+
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <form method="POST" action="{{ route('admin.festival.update') }}" class="space-y-4">
+                    @csrf
+                    @method('PUT')
+                    <div class="grid grid-cols-2 gap-4">
+                        <div>
+                            <x-input-label for="aufbau_start" value="{{ __('Aufbau Start') }}" />
+                            <x-text-input type="date" id="aufbau_start" name="aufbau_start" :value="$festival->aufbau_start?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                        <div>
+                            <x-input-label for="aufbau_end" value="{{ __('Aufbau Ende') }}" />
+                            <x-text-input type="date" id="aufbau_end" name="aufbau_end" :value="$festival->aufbau_end?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                        <div>
+                            <x-input-label for="festival_start" value="{{ __('Festival Start') }}" />
+                            <x-text-input type="date" id="festival_start" name="festival_start" :value="$festival->festival_start?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                        <div>
+                            <x-input-label for="festival_end" value="{{ __('Festival Ende') }}" />
+                            <x-text-input type="date" id="festival_end" name="festival_end" :value="$festival->festival_end?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                        <div>
+                            <x-input-label for="abbau_start" value="{{ __('Abbau Start') }}" />
+                            <x-text-input type="date" id="abbau_start" name="abbau_start" :value="$festival->abbau_start?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                        <div>
+                            <x-input-label for="abbau_end" value="{{ __('Abbau Ende') }}" />
+                            <x-text-input type="date" id="abbau_end" name="abbau_end" :value="$festival->abbau_end?->format('Y-m-d')" required class="mt-1 block w-full" />
+                        </div>
+                    </div>
+                    <x-primary-button class="mt-4">{{ __('Speichern') }}</x-primary-button>
+                </form>
+            </div>
+
+            <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <x-calendar :festival="$festival" />
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/components/calendar.blade.php
+++ b/resources/views/components/calendar.blade.php
@@ -1,0 +1,57 @@
+@props(['festival'])
+@php
+    $start = collect([
+        $festival->aufbau_start,
+        $festival->festival_start,
+        $festival->abbau_start
+    ])->filter()->min();
+    $end = collect([
+        $festival->aufbau_end,
+        $festival->festival_end,
+        $festival->abbau_end
+    ])->filter()->max();
+    $periodStart = \Carbon\Carbon::parse($start)->startOfWeek(1);
+    $periodEnd = \Carbon\Carbon::parse($end)->endOfWeek(0);
+    $days = [];
+    $current = $periodStart->clone();
+    while($current <= $periodEnd){
+        $days[] = $current->clone();
+        $current->addDay();
+    }
+@endphp
+<table class="min-w-full border text-center">
+    <thead>
+        <tr>
+            <th class="p-1">Mo</th>
+            <th class="p-1">Di</th>
+            <th class="p-1">Mi</th>
+            <th class="p-1">Do</th>
+            <th class="p-1">Fr</th>
+            <th class="p-1">Sa</th>
+            <th class="p-1">So</th>
+        </tr>
+    </thead>
+    <tbody>
+    @foreach($days as $i => $day)
+        @if($i % 7 === 0)
+            <tr>
+        @endif
+        @php
+            $classes = '';
+            if($day->between($festival->aufbau_start, $festival->aufbau_end)){
+                $classes = 'bg-yellow-200';
+            }
+            if($day->between($festival->festival_start, $festival->festival_end)){
+                $classes = 'bg-green-200';
+            }
+            if($day->between($festival->abbau_start, $festival->abbau_end)){
+                $classes = 'bg-red-200';
+            }
+        @endphp
+        <td class="border p-1 {{ $classes }}">{{ $day->format('d.m.') }}</td>
+        @if($i % 7 === 6)
+            </tr>
+        @endif
+    @endforeach
+    </tbody>
+</table>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -26,6 +26,9 @@
                         <x-nav-link :href="route('admin.workdays.index')" :active="request()->routeIs('admin.workdays.*')">
                             {{ __('Admin Dashboard') }}
                         </x-nav-link>
+                        <x-nav-link :href="route('admin.festival.edit')" :active="request()->routeIs('admin.festival.*')">
+                            {{ __('Festival Einstellungen') }}
+                        </x-nav-link>
                     @endrole
                 </div>
             </div>
@@ -92,6 +95,9 @@
             @role('admin')
                 <x-responsive-nav-link :href="route('admin.workdays.index')" :active="request()->routeIs('admin.workdays.*')">
                     {{ __('Admin Dashboard') }}
+                </x-responsive-nav-link>
+                <x-responsive-nav-link :href="route('admin.festival.edit')" :active="request()->routeIs('admin.festival.*')">
+                    {{ __('Festival Einstellungen') }}
                 </x-responsive-nav-link>
             @endrole
         </div>

--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -5,8 +5,15 @@
         </h2>
     </x-slot>
 
-    <div class="py-12">
+    @php($festival = \App\Models\Festival::first())
+
+    <div class="py-12 space-y-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            @if($festival)
+                <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
+                    <x-calendar :festival="$festival" />
+                </div>
+            @endif
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
                 <table class="min-w-full">
                     <thead>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\WorkdayController;
 use App\Http\Controllers\Admin\WorkdayController as AdminWorkdayController;
+use App\Http\Controllers\Admin\FestivalController as AdminFestivalController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
@@ -26,6 +27,8 @@ Route::middleware('auth')->group(function(){
 });
 
 Route::middleware(['auth','role:admin'])->prefix('admin')->name('admin.')->group(function(){
+    Route::get('festival', [AdminFestivalController::class, 'edit'])->name('festival.edit');
+    Route::put('festival', [AdminFestivalController::class, 'update'])->name('festival.update');
     Route::resource('workdays', AdminWorkdayController::class);
 });
 


### PR DESCRIPTION
## Summary
- create `Festival` model and migration
- add admin controller and edit page to update festival date ranges
- show festival calendar on `Meine Tage` and admin pages
- add reusable calendar component
- update navigation with festival link
- seed demo festival data

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6844a152e900832d8faf6b668f93e220