### PR TITLE
Allow users to pick workday type

### DIFF
--- a/app/Http/Controllers/Admin/WorkdayController.php
+++ b/app/Http/Controllers/Admin/WorkdayController.php
@@ -11,18 +11,26 @@ class WorkdayController extends Controller
     public function index()
     {
         $workdays = Workday::orderBy('day')->get();
+
         return view('workdays.index', compact('workdays'));
     }
 
-    public function signup(Workday $workday)
+    public function signup(Request $request, Workday $workday)
     {
-        auth()->user()->workdays()->attach($workday->id);
+        $data = $request->validate([
+            'status' => ['required', 'in:A,0.5,1'],
+        ]);
+        auth()->user()->workdays()->syncWithoutDetaching([
+            $workday->id => ['status' => $data['status']],
+        ]);
+
         return back()->with('success', 'Du bist dabei! 🎉');
     }
 
     public function cancel(Workday $workday)
     {
         auth()->user()->workdays()->detach($workday->id);
+
         return back()->with('warning', 'Schade, dass du abspringst…');
     }
 }

--- a/app/Http/Controllers/WorkdayController.php
+++ b/app/Http/Controllers/WorkdayController.php
@@ -20,9 +20,15 @@ class WorkdayController extends Controller
     /**
      * Sign the authenticated user up for a workday.
      */
-    public function signup(Workday $workday)
+    public function signup(Request $request, Workday $workday)
     {
-        auth()->user()->workdays()->attach($workday->id);
+        $data = $request->validate([
+            'status' => ['required', 'in:A,0.5,1'],
+        ]);
+
+        auth()->user()->workdays()->syncWithoutDetaching([
+            $workday->id => ['status' => $data['status']],
+        ]);
 
         return back()->with('success', 'Du bist dabei! 🎉');
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,7 +9,7 @@ use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasFactory, Notifiable, HasRoles;
+    use HasFactory, HasRoles, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -47,6 +47,8 @@ class User extends Authenticatable
      */
     public function workdays()
     {
-        return $this->belongsToMany(Workday::class)->withTimestamps();
+        return $this->belongsToMany(Workday::class)
+            ->withPivot('status')
+            ->withTimestamps();
     }
 }

--- a/app/Models/Workday.php
+++ b/app/Models/Workday.php
@@ -27,6 +27,8 @@ class Workday extends Model
      */
     public function users()
     {
-        return $this->belongsToMany(User::class)->withTimestamps();
+        return $this->belongsToMany(User::class)
+            ->withPivot('status')
+            ->withTimestamps();
     }
 }

--- a/database/migrations/2025_06_07_205645_add_status_to_user_workday_table.php
+++ b/database/migrations/2025_06_07_205645_add_status_to_user_workday_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_workday', function (Blueprint $table) {
+            $table->string('status')->default('1');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_workday', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add pivot column `status` for workday preferences
- show admin overview of all workday choices
- allow selecting `A`, `0.5` or `1` for each day

## Testing
- `./vendor/bin/pint app/Http/Controllers/Admin/WorkdayController.php app/Http/Controllers/WorkdayController.php app/Models/User.php app/Models/Workday.php resources/views/workdays/index.blade.php database/migrations/2025_06_07_205645_add_status_to_user_workday_table.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6844a6daffa8832db3b88c98e0e98522