### PR TITLE
Fix Blade syntax in workdays view

### DIFF
--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -5,7 +5,9 @@
         </h2>
     </x-slot>
 
-    @php($festival = \App\Models\Festival::first())
+    @php
+        $festival = \App\Models\Festival::first();
+    @endphp
 
     <div class="py-12 space-y-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
@@ -27,7 +29,9 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @php($users = \App\Models\User::orderBy('name')->get())
+                                @php
+                                    $users = \App\Models\User::orderBy('name')->get();
+                                @endphp
                                 @foreach($users as $user)
                                     <tr class="border-t">
                                         <td class="p-2 text-left">{{ $user->name }}</td>


### PR DESCRIPTION
## Summary
- correct `@php` usage in `resources/views/workdays/index.blade.php`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6844a8ff56c0832db05ba880d091f2af