### PR TITLE
Fix missing signup buttons for admins

### DIFF
--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -18,7 +18,7 @@
             @endif
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
                 @if(auth()->user()->hasRole('admin'))
-                    <div class="overflow-x-auto">
+                    <div class="overflow-x-auto mb-6">
                         <table class="min-w-max text-center">
                             <thead>
                                 <tr>
@@ -46,8 +46,9 @@
                             </tbody>
                         </table>
                     </div>
-                @else
-                    <table class="min-w-full">
+                @endif
+
+                <table class="min-w-full">
                         <thead>
                             <tr>
                                 <th class="text-left">{{ __('Datum') }}</th>
@@ -83,7 +84,6 @@
                             @endforeach
                         </tbody>
                     </table>
-                @endif
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- show signup table for admins too so they can register for workdays

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6844ad096d78832d8feb08a4d24f6dc8