### PR TITLE
Add workday totals to admin table

### DIFF
--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -26,6 +26,7 @@
                                     @foreach($workdays as $day)
                                         <th class="p-2 whitespace-nowrap">{{ $day->day->format('d.m.') }}</th>
                                     @endforeach
+                                    <th class="p-2">{{ __('Summe') }}</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -41,6 +42,12 @@
                                             @endphp
                                             <td class="p-2 border">{{ $entry }}</td>
                                         @endforeach
+                                        @php
+                                            $total = $user->workdays->sum(function ($w) {
+                                                return $w->pivot->status === '0.5' ? 0.5 : 1;
+                                            });
+                                        @endphp
+                                        <td class="p-2 font-semibold">{{ $total }}</td>
                                     </tr>
                                 @endforeach
                             </tbody>


### PR DESCRIPTION
## Summary
- show total signup days per user in admin workday overview

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_6844bc108df0832d8666fc6e8144ba34