### PR TITLE
Fix pivot status lookups

### DIFF
--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -38,7 +38,7 @@
                                         <td class="p-2 text-left">{{ $user->name }}</td>
                                         @foreach($workdays as $day)
                                             @php
-                                                $entry = optional($user->workdays->firstWhere('id', $day->id))->pivot->status;
+                                                $entry = optional($user->workdays->firstWhere('id', $day->id))->pivot?->status;
                                             @endphp
                                             <td class="p-2 border">{{ $entry }}</td>
                                         @endforeach
@@ -66,7 +66,7 @@
                         <tbody>
                             @foreach($workdays as $workday)
                                 @php
-                                    $current = optional($workday->users->firstWhere('id', auth()->id()))->pivot->status;
+                                    $current = optional($workday->users->firstWhere('id', auth()->id()))->pivot?->status;
                                     $rowClass = match($current) {
                                         'A' => 'bg-yellow-200',
                                         '0.5' => 'bg-teal-200',


### PR DESCRIPTION
## Summary
- make pivot status retrieval null-safe for workday listings

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6844c93727e8832da615481347de8d0e