### PR TITLE
Limit admin workday endpoints

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -29,7 +29,9 @@ Route::middleware('auth')->group(function(){
 Route::middleware(['auth','role:admin'])->prefix('admin')->name('admin.')->group(function(){
     Route::get('festival', [AdminFestivalController::class, 'edit'])->name('festival.edit');
     Route::put('festival', [AdminFestivalController::class, 'update'])->name('festival.update');
-    Route::resource('workdays', AdminWorkdayController::class);
+    Route::get('workdays', [AdminWorkdayController::class, 'index'])->name('workdays.index');
+    Route::post('workdays/{workday}/signup', [AdminWorkdayController::class, 'signup'])->name('workdays.signup');
+    Route::delete('workdays/{workday}/cancel', [AdminWorkdayController::class, 'cancel'])->name('workdays.cancel');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- remove resource routes for admin workdays
- define only index, signup and cancel endpoints explicitly

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6844cc36060c832d878434610c4e7345