### PR TITLE
Eager load workday data in controllers

### DIFF
--- a/app/Http/Controllers/Admin/WorkdayController.php
+++ b/app/Http/Controllers/Admin/WorkdayController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Models\Festival;
+use App\Models\User;
 use App\Models\Workday;
 use Illuminate\Http\Request;
 
@@ -10,9 +12,11 @@ class WorkdayController extends Controller
 {
     public function index()
     {
-        $workdays = Workday::orderBy('day')->get();
+        $workdays = Workday::with('users')->orderBy('day')->get();
+        $festival = Festival::first();
+        $users = User::with('workdays')->orderBy('name')->get();
 
-        return view('workdays.index', compact('workdays'));
+        return view('workdays.index', compact('workdays', 'festival', 'users'));
     }
 
     public function signup(Request $request, Workday $workday)

--- a/app/Http/Controllers/WorkdayController.php
+++ b/app/Http/Controllers/WorkdayController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Festival;
+use App\Models\User;
 use App\Models\Workday;
 use Illuminate\Http\Request;
 
@@ -12,9 +14,13 @@ class WorkdayController extends Controller
      */
     public function index()
     {
-        $workdays = Workday::orderBy('day')->get();
+        $workdays = Workday::with('users')->orderBy('day')->get();
+        $festival = Festival::first();
+        $users = auth()->user()->hasRole('admin')
+            ? User::with('workdays')->orderBy('name')->get()
+            : collect();
 
-        return view('workdays.index', compact('workdays'));
+        return view('workdays.index', compact('workdays', 'festival', 'users'));
     }
 
     /**

--- a/resources/views/components/calendar.blade.php
+++ b/resources/views/components/calendar.blade.php
@@ -1,4 +1,4 @@
-@props(['festival'])
+@props(['festival', 'workdays'])
 @php
     $start = collect([
         $festival->aufbau_start,
@@ -18,6 +18,7 @@
         $days[] = $current->clone();
         $current->addDay();
     }
+    $workdaysByDate = $workdays->keyBy(fn($w) => $w->day->toDateString());
 @endphp
 <div class="overflow-x-auto">
 <table class="min-w-max border text-center">
@@ -43,8 +44,8 @@
                         $classes = 'bg-red-200';
                     }
 
-                    $workday = \App\Models\Workday::where('day', $day->toDateString())->first();
-                    $current = optional($workday?->users->firstWhere('id', auth()->id()))->pivot->status;
+                    $workday = $workdaysByDate->get($day->toDateString());
+                    $current = optional($workday?->users->firstWhere('id', auth()->id()))->pivot?->status;
                 @endphp
                 <td class="border p-1 space-y-1 {{ $classes }}">
                     {{ $day->format('d.m.') }}

--- a/resources/views/workdays/index.blade.php
+++ b/resources/views/workdays/index.blade.php
@@ -5,15 +5,13 @@
         </h2>
     </x-slot>
 
-    @php
-        $festival = \App\Models\Festival::first();
-    @endphp
+
 
     <div class="py-12 space-y-6">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             @if($festival)
                 <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6 mb-6">
-                    <x-calendar :festival="$festival" />
+                    <x-calendar :festival="$festival" :workdays="$workdays" />
                 </div>
             @endif
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
@@ -30,9 +28,6 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @php
-                                    $users = \App\Models\User::orderBy('name')->get();
-                                @endphp
                                 @foreach($users as $user)
                                     <tr class="border-t">
                                         <td class="p-2 text-left">{{ $user->name }}</td>


### PR DESCRIPTION
## Summary
- eager load users for workdays
- fetch festival and user lists from controllers
- pass workdays to the calendar component
- remove direct DB queries from templates

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6844cc382860832d9d5b5bfae3967244