### PR TITLE
Fix calendar component usage in festival admin view

### DIFF
--- a/app/Http/Controllers/Admin/FestivalController.php
+++ b/app/Http/Controllers/Admin/FestivalController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Festival;
+use App\Models\Workday;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 
@@ -28,7 +29,9 @@ class FestivalController extends Controller
             ]);
         }
 
-        return view('admin.festival.edit', compact('festival'));
+        $workdays = Workday::with('users')->orderBy('day')->get();
+
+        return view('admin.festival.edit', compact('festival', 'workdays'));
     }
 
     public function update(Request $request)

--- a/resources/views/admin/festival/edit.blade.php
+++ b/resources/views/admin/festival/edit.blade.php
@@ -34,7 +34,7 @@
             </div>
 
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg p-6">
-                <x-calendar :festival="$festival" />
+                <x-calendar :festival="$festival" :workdays="$workdays" />
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- load workdays with users in `FestivalController@edit`
- pass the loaded workdays to the calendar component in the admin festival view

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6844e75f1a94832dace7b258a3ea0c5d