### PR TITLE
Fix default for calendar component

### DIFF
--- a/resources/views/components/calendar.blade.php
+++ b/resources/views/components/calendar.blade.php
@@ -1,4 +1,4 @@
-@props(['festival', 'workdays'])
+@props(['festival', 'workdays' => collect()])
 @php
     $start = collect([
         $festival->aufbau_start,


### PR DESCRIPTION
## Summary
- set a default value for the `workdays` property in the calendar component

## Testing
- `php vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_6844e81ea744832d86c651b8dba8826a